### PR TITLE
feat: implement json output

### DIFF
--- a/src/commands/send-many-memo.ts
+++ b/src/commands/send-many-memo.ts
@@ -157,7 +157,7 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
 
     let outputEntries: Record<
       string,
-      string | number | boolean | Record<string, string | number>[]
+      string | boolean | Record<string, string>[]
     > = {};
 
     outputEntries = {
@@ -167,11 +167,11 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
         memo: r.memo || '',
       })),
       fee: tx.auth.getFee().toString(),
-      nonce: tx.auth.spendingCondition?.nonce.toNumber() || '?',
+      nonce: tx.auth.spendingCondition?.nonce.toString() || '?',
       contract: contractIdentifier,
       sender: getAddress(flags.privateKey, network),
       totalAmount: (tx.postConditions
-        .values as STXPostCondition[])[0].amount.toNumber(),
+        .values as STXPostCondition[])[0].amount.toString(),
       transactionHex: tx.serialize().toString('hex'),
     };
 
@@ -187,7 +187,11 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
             network.chainId === ChainID.Mainnet ? 'mainnet' : 'testnet'
           }`;
         } else {
-          console.log(result.toString());
+          if (flags.jsonOutput) {
+            console.log(JSON.stringify({ transactionId: result.toString() }));
+          } else {
+            console.log(result.toString());
+          }
         }
       } else {
         broadcastFailed = true;
@@ -195,7 +199,13 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
         outputEntries['error'] = JSON.stringify(result, null, 2);
       }
     } else if (flags.quiet) {
-      console.log(tx.serialize().toString('hex'));
+      if (flags.jsonOutput) {
+        console.log(
+          JSON.stringify({ transactionHex: tx.serialize().toString('hex') })
+        );
+      } else {
+        console.log(tx.serialize().toString('hex'));
+      }
     }
 
     if (verbose) {

--- a/src/commands/send-many-memo.ts
+++ b/src/commands/send-many-memo.ts
@@ -72,6 +72,11 @@ only the transaction ID will be logged. If the quiet flagged is passed without b
 only the raw transaction hex will be logged.
 `,
     }),
+    jsonOutput: flags.boolean({
+      char: 'j',
+      default: false,
+      description: 'Output data in JSON format',
+    }),
     contractAddress: flags.string({
       char: 'c',
       description:
@@ -136,7 +141,8 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
       network.coreApiUrl = flags.nodeUrl;
     }
 
-    const contractIdentifier = this.getContract(network);
+    const contractIdentifier =
+      flags.contractAddress || this.getContract(network);
 
     const tx = await sendMany({
       recipients,
@@ -149,44 +155,71 @@ Example: STADMRP577SC3MCNP7T3PRSTZBJ75FJ59JGABZTW,100,memo ST2WPFYAW85A0YK9ACJR8
 
     const verbose = !flags.quiet;
 
-    if (verbose) {
-      this.log('Recipients:');
-      recipients.forEach(r => {
-        this.log(`Address: ${r.address}`);
-        this.log(`Amount: ${r.amount}`);
-        this.log(`Memo: ${r.memo || ''}`);
-        this.log('----------');
-      });
-      this.log('Fee:', tx.auth.getFee().toString());
-      this.log('Nonce:', tx.auth.spendingCondition?.nonce.toNumber());
-      this.log('Contract:', contractIdentifier);
-      this.log('Sender:', getAddress(flags.privateKey, network));
-      const [postCondition] = tx.postConditions.values as STXPostCondition[];
-      this.log('Total amount:', postCondition.amount.toNumber());
-      this.log('Transaction hex:', tx.serialize().toString('hex'));
-    }
+    let outputEntries: Record<
+      string,
+      string | number | boolean | Record<string, string | number>[]
+    > = {};
 
+    outputEntries = {
+      recipients: recipients.map(r => ({
+        address: r.address,
+        amount: r.amount,
+        memo: r.memo || '',
+      })),
+      fee: tx.auth.getFee().toString(),
+      nonce: tx.auth.spendingCondition?.nonce.toNumber() || '?',
+      contract: contractIdentifier,
+      sender: getAddress(flags.privateKey, network),
+      totalAmount: (tx.postConditions
+        .values as STXPostCondition[])[0].amount.toNumber(),
+      transactionHex: tx.serialize().toString('hex'),
+    };
+
+    let broadcastFailed = false;
     if (flags.broadcast) {
       const result = await broadcastTransaction(tx, network);
       if (typeof result === 'string') {
         if (verbose) {
-          this.log('Transaction ID:', result);
+          outputEntries['success'] = true;
+          outputEntries['transactionId'] = result;
           const explorerLink = `https://explorer.stacks.co/txid/0x${result}`;
-          this.log(
-            'View in explorer:',
-            `${explorerLink}?chain=${
-              network.chainId === ChainID.Mainnet ? 'mainnet' : 'testnet'
-            }`
-          );
+          outputEntries['explorerLink'] = `${explorerLink}?chain=${
+            network.chainId === ChainID.Mainnet ? 'mainnet' : 'testnet'
+          }`;
         } else {
           console.log(result.toString());
         }
       } else {
-        this.log('Transaction rejected:', result);
-        process.exit(1);
+        broadcastFailed = true;
+        outputEntries['success'] = false;
+        outputEntries['error'] = JSON.stringify(result, null, 2);
       }
     } else if (flags.quiet) {
       console.log(tx.serialize().toString('hex'));
+    }
+
+    if (verbose) {
+      if (flags.jsonOutput) {
+        this.log(JSON.stringify(outputEntries, null, 2));
+      } else {
+        for (const [key, value] of Object.entries(outputEntries)) {
+          if (Array.isArray(value)) {
+            this.log(`${key}:`);
+            value.forEach(obj => {
+              Object.entries(obj).forEach(([k, v]) => {
+                this.log(`  ${k}: ${v}`);
+              });
+              this.log('  ----------');
+            });
+          } else {
+            this.log(`${key}: ${value}`);
+          }
+        }
+      }
+    }
+
+    if (broadcastFailed) {
+      process.exit(1);
     }
   }
 }


### PR DESCRIPTION
Implements JSON-formatted output. Option is enabled with the command flag `-j` or `--jsonOutput`.

Example json output when using the `--jsonOutput` flag:
```json
{
  "recipients": [
    {
      "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR",
      "amount": "1234",
      "memo": "hellotest"
    },
    {
      "address": "ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR",
      "amount": "3456",
      "memo": "test3"
    },
    {
      "address": "ST2HT3XGCAYPDEX5P79HN0X2Q98PP89SKX20KRR0S",
      "amount": "2939",
      "memo": "helloooo"
    }
  ],
  "fee": "411",
  "nonce": "20",
  "contract": "ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.send-many-memo",
  "sender": "STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6",
  "totalAmount": "7629",
  "transactionHex": "80800000000400164247d6f2b425ac5771423ae6c80c754f7172b00000000000000014000000000000019b000038c88876a76486c718a02f887116718cd826fdbe16c70221a3967d0dd8bea7b241a4ba7924b769ba742b6bc44cc93a33658f6aa84e420c2751ce632fa5c90eb203020000000100021a164247d6f2b425ac5771423ae6c80c754f7172b0010000000000001dcd021a43596b5386f466863e25658ddf94bd0fadab00480e73656e642d6d616e792d6d656d6f0973656e642d6d616e79000000010b000000030c00000003046d656d6f020000000968656c6c6f7465737402746f051a62b0e91cc557e583c3d1f9dfe468ace76d2f0374047573747801000000000000000000000000000004d20c00000003046d656d6f0200000005746573743302746f051a62b0e91cc557e583c3d1f9dfe468ace76d2f037404757374780100000000000000000000000000000d800c00000003046d656d6f020000000868656c6c6f6f6f6f02746f051aa3a1f60c57acd774b63a635074574a2d642733e804757374780100000000000000000000000000000b7b",
  "success": true,
  "transactionId": "993816d20fedd1bb1f69373df19d789f9bbca1310d4821d6996031b6a228b655",
  "explorerLink": "https://explorer.stacks.co/txid/0x993816d20fedd1bb1f69373df19d789f9bbca1310d4821d6996031b6a228b655?chain=testnet"
}
```

The non-json output is mostly the same format, example:
```
recipients:
  address: ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR
  amount: 1234
  memo: hellotest
  ----------
  address: ST1HB1T8WRNBYB0Y3T7WXZS38NKKPTBR3EG9EPJKR
  amount: 3456
  memo: test3
  ----------
  address: ST2HT3XGCAYPDEX5P79HN0X2Q98PP89SKX20KRR0S
  amount: 2939
  memo: helloooo
  ----------
fee: 411
nonce: 11
contract: ST11NJTTKGVT6D1HY4NJRVQWMQM7TVAR091EJ8P2Y.send-many-memo
sender: STB44HYPYAT2BB2QE513NSP81HTMYWBJP02HPGK6
totalAmount: 7629
transactionHex: 80800000000400164247d6f2b425ac5771423ae6c80c754f7172b0000000000000000b000000000000019b0000ef9be3a3a2d730013358a16cad7578a8e160f205b5326a62ca62076c8f622bb43a1cfb230f0fc6ba85b089a1c19a24fa542992b52850b6a33da369729d5b0ddf03020000000100021a164247d6f2b425ac5771423ae6c80c754f7172b0010000000000001dcd021a43596b5386f466863e25658ddf94bd0fadab00480e73656e642d6d616e792d6d656d6f0973656e642d6d616e79000000010b000000030c00000003046d656d6f020000000968656c6c6f7465737402746f051a62b0e91cc557e583c3d1f9dfe468ace76d2f0374047573747801000000000000000000000000000004d20c00000003046d656d6f0200000005746573743302746f051a62b0e91cc557e583c3d1f9dfe468ace76d2f037404757374780100000000000000000000000000000d800c00000003046d656d6f020000000868656c6c6f6f6f6f02746f051aa3a1f60c57acd774b63a635074574a2d642733e804757374780100000000000000000000000000000b7b
success: true
transactionId: ed10dd29f1f45648e948b600092c0668a932598ac382517aa5d0f20c1fad0593
explorerLink: https://explorer.stacks.co/txid/0xed10dd29f1f45648e948b600092c0668a932598ac382517aa5d0f20c1fad0593?chain=testnet
```

